### PR TITLE
Changes from background agent bc-9c196119-8fcf-4bde-9c0f-c8ca578de070

### DIFF
--- a/experiments/phase2_priority_net.py
+++ b/experiments/phase2_priority_net.py
@@ -453,6 +453,18 @@ def main():
             'dropout': 0.15,
             'learning_rate': 8e-4
         })()
+
+    # Coerce critical hyperparameters to correct numeric types
+    try:
+        if hasattr(config, 'learning_rate'):
+            config.learning_rate = float(config.learning_rate)
+    except Exception:
+        config.learning_rate = 8e-4
+    try:
+        if hasattr(config, 'dropout'):
+            config.dropout = float(config.dropout)
+    except Exception:
+        config.dropout = 0.15
     
     # Load training data
     data_dir = Path(args.data_dir)


### PR DESCRIPTION
Coerce `learning_rate` and `dropout` config values to float to resolve `TypeError` in `torch.optim.AdamW`.

The `TypeError` occurred because `learning_rate` was passed as a string to `torch.optim.AdamW`'s constructor. This change ensures that these critical hyperparameters are always numeric, even if loaded as strings from the YAML configuration, preventing runtime errors during optimizer initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c196119-8fcf-4bde-9c0f-c8ca578de070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c196119-8fcf-4bde-9c0f-c8ca578de070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

